### PR TITLE
add certbot container

### DIFF
--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -1,0 +1,22 @@
+# Container for the Teleport
+FROM arm64v8/ubuntu:latest
+
+# Install snapd to be able install certbot
+RUN apt update
+
+# install certbot
+RUN DEBIAN_FRONTEND=noninteractive apt install -y certbot
+
+# Prepare the Certbot command 
+RUN ln -s /snap/bin/certbot /usr/bin/certbot
+
+# clean image
+RUN apt-get clean; \
+    rm -rf /var/lib/apt/lists/* 
+
+# expose ports
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+
+# run Teleport
+CMD ["/usr/bin/bash"]

--- a/certbot/README.md
+++ b/certbot/README.md
@@ -1,0 +1,23 @@
+# Destination: 
+This Dockerfile allows to create a certbot image.
+
+# How to use:
+
+## 1. Build image
+```sh
+docker build -t certbot ./
+```
+
+## 2. Run container and mount directory
+```sh
+docker run -ti -p 80:80 -p 443:443 --mount=type=bind,source=etc/letsencrypt/archive,target=/opt/configs/certs --rm certbot
+```
+
+## 3. Run command to generate certificate (check commandline on certbot website)
+```sh
+sudo certbot certonly --standalone
+```
+
+# Links:
+* https://certbot.eff.org/instructions - Certbot Instructions
+* https://letsencrypt.org/docs/ - Let's Encrypt Documentation


### PR DESCRIPTION
This is a simple container, to generate let's encrypt certificates in manual mod. Also it is easy to modify Dockerfile and convert it in a continuously running, or scheduled, to automatically generate certificates.